### PR TITLE
Dev: Add a new 'cfg_explore' function to get cfg and proj as inputs

### DIFF
--- a/cfgexplorer/__init__.py
+++ b/cfgexplorer/__init__.py
@@ -1,4 +1,4 @@
 from .endpoint import VisEndpoint, CFGVisEndpoint, FGraphVisEndpoint
 from .explorer import CFGExplorer
 from .cli import CFGExplorerCLI
-from .utils import cfg_explore
+from .utils import cfg_explore, cfg_explore_get_cfg


### PR DESCRIPTION
I thought it might be helpful to have a function that takes the cfg and the loaded project as inputs instead of binary file itself. This enables the users that user ‘angr’ tool to visualize their cfgs with custom settings for the cfg.