### PR TITLE
extend cfg-explorer to RISC-V rv32 and other platforms

### DIFF
--- a/cfgexplorer/cli.py
+++ b/cfgexplorer/cli.py
@@ -4,6 +4,7 @@ l = logging.getLogger('axt.cfgexplorer')
 
 import argparse
 import angr
+from angr_platforms.risc_v import *
 import os
 
 from .explorer import CFGExplorer

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ flask
 networkx
 graphviz
 angr
+git+https://github.com/angr/angr-platforms.git


### PR DESCRIPTION
The current cfg-explorer doesn't work on rv32 architectures. This can be solved by using an extension of the angr available at [angr_platforms](https://github.com/angr/angr-platforms).