### PR TITLE
Add docker image for non-Linux users

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM python:3.10-slim
+# Install system-level dependencies including CMake
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    graphviz \
+    cmake \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+
+WORKDIR /app
+COPY . /app
+
+
+
+# Install Python dependencies
+RUN pip install --upgrade pip
+RUN pip install -r requirements.txt
+RUN pip install -e .
+
+EXPOSE 5000
+
+# Run the application
+ENTRYPOINT [ "cfgexplorer", "-P 5000"]

--- a/Dockerfile.quickrun
+++ b/Dockerfile.quickrun
@@ -1,0 +1,11 @@
+FROM cfg-explorer:latest
+
+VOLUME [ "/app/input" ]
+
+WORKDIR /app
+EXPOSE 5000
+
+ENTRYPOINT []
+
+CMD ["sh", "-c", "cd /app/input &&  make && cfgexplorer -P 5000 target"]
+

--- a/README.md
+++ b/README.md
@@ -48,6 +48,34 @@ Besides, now it can also export multiple formats of static CFG files to your loc
 
 CFGs starting from multiple start addresses or for multiple functions can also be automatically exported to multiple files at once with different suffixes in their filenames.
 
+## Quick Start: Use Docker Image
+
+1. build the docker image
+
+```bash
+docker build -t cfg-explorer .
+```
+
+2. run the docker container, mount the directory containing the binary to be analyzed to `/data` in the container
+
+
+For example, use [`examples/specrand_base.i386`](./examples/specrand_base.i386) as the binary and output the CFG to `./output/cfg.pdf`:
+
+```bash
+docker run -v $(pwd)/examples/specrand_base.i386:/data/binary  \
+    -v $(pwd)/output:/output cfg-explorer /data/binary -l -o /output/cfg.pdf
+```
+
+Or let it start a web server and open the browser to view the CFG:
+
+
+```bash
+docker run -p 8000:5000 -v $(pwd)/examples/specrand_base.i386:/data/binary  \
+ cfg-explorer /data/binary
+```
+
+You can view the CFG in your browser by visiting `http://localhost:8000/api/cfg/0x[entry_address]` according to the output of the command.
+
 
 ## Note
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,19 @@ docker run -p 5000:5000 -v $(pwd)/examples/specrand_base.i386:/data/binary  \
 You can view the CFG in your browser by visiting `http://localhost:5000/api/cfg/0x[entry_address]` according to the output of the command.
 
 
+Or you can use the quick run image (available as [yangzhou301/cfg-explorer-quickrun](https://hub.docker.com/repository/docker/yangzhou301/cfg-explorer-quickrun/general)) if you don't want to build the binary
+
+```bash
+docker build -t cfg-explorer-quickrun -f Dockerfile.quickrun .
+```
+
+Mount the directory you want to build to `app/input` and set its output as `target`. You can refer to ['examples/helloworld'](./examples/helloworld) for a simple example.
+
+```bash
+docker run -p 5000:5000 -v $(pwd)/examples/helloworld:/app/input cfg-explorer-quickrun
+```
+
+
 ## Note
 
 This project is in its very early stage!

--- a/README.md
+++ b/README.md
@@ -63,18 +63,18 @@ For example, use [`examples/specrand_base.i386`](./examples/specrand_base.i386) 
 
 ```bash
 docker run -v $(pwd)/examples/specrand_base.i386:/data/binary  \
-    -v $(pwd)/output:/output cfg-explorer /data/binary -l -o /output/cfg.pdf
+    -v $(pwd)/output:/output cfg-explorer /data/binary -o /output/cfg.pdf
 ```
 
 Or let it start a web server and open the browser to view the CFG:
 
 
 ```bash
-docker run -p 8000:5000 -v $(pwd)/examples/specrand_base.i386:/data/binary  \
+docker run -p 5000:5000 -v $(pwd)/examples/specrand_base.i386:/data/binary  \
  cfg-explorer /data/binary
 ```
 
-You can view the CFG in your browser by visiting `http://localhost:8000/api/cfg/0x[entry_address]` according to the output of the command.
+You can view the CFG in your browser by visiting `http://localhost:5000/api/cfg/0x[entry_address]` according to the output of the command.
 
 
 ## Note

--- a/cfgexplorer/explorer.py
+++ b/cfgexplorer/explorer.py
@@ -33,4 +33,4 @@ class CFGExplorer(object):
         return render_template("index.html", start_url ="http://localhost:%d%s" % (self.port, self.start_url))
 
     def run(self):
-        self._app.run(debug=True, use_reloader=False, port=self.port)
+        self._app.run(debug=True, use_reloader=False, port=self.port, host='0.0.0.0')

--- a/examples/helloworld/.gitignore
+++ b/examples/helloworld/.gitignore
@@ -1,0 +1,40 @@
+# Created by https://www.toptal.com/developers/gitignore/api/c++
+# Edit at https://www.toptal.com/developers/gitignore?templates=c++
+
+### C++ ###
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+# End of https://www.toptal.com/developers/gitignore/api/c++
+
+target

--- a/examples/helloworld/hello.cpp
+++ b/examples/helloworld/hello.cpp
@@ -1,0 +1,7 @@
+#include <iostream>
+using namespace std;
+
+int main() {
+    cout << "Hello World!";
+    return 0;
+}

--- a/examples/helloworld/makefile
+++ b/examples/helloworld/makefile
@@ -1,0 +1,17 @@
+CXX = g++
+
+CXXFLAGS = -g -Wall -Wextra -Werror -pedantic -O3
+
+TARGET = target
+
+SRC = hello.cpp
+
+all: $(TARGET)
+
+$(TARGET): $(SRC)
+	$(CXX) $(CXXFLAGS) -o $(TARGET) $(SRC)
+
+.PHONY: clean
+
+clean:
+	rm -f $(TARGET)


### PR DESCRIPTION
- Add a Dockerfile to install and execute `cfg-explorer`
- Add use-case examples in `Readme.md`

Besides, I also posted the docker image [here](https://hub.docker.com/repository/docker/yangzhou301/cfg-explorer/). Feel free to test it.

Now, users without Linux OS can also benefit from this package.